### PR TITLE
Increase the size of the article buffer to stop inventory crashing

### DIFF
--- a/gBrogue Source/gBrogueCode/Items.c
+++ b/gBrogue Source/gBrogueCode/Items.c
@@ -1396,7 +1396,7 @@ void call(item *theItem) {
 // Portions of known items (a potion of "strength") will be in teal -- gsr
 //  BaseColor itself will be the color that the name reverts to outside of these colored portions.
 void itemName(item *theItem, char *root, boolean includeDetails, boolean includeArticle, color *baseColor) {
-	char buf[DCOLS * 5], pluralization[10], article[10] = "",
+	char buf[DCOLS * 5], pluralization[10], article[25] = "",
 	grayEscapeSequence[5], purpleEscapeSequence[5], yellowEscapeSequence[5], cyanEscapeSequence[5], baseEscapeSequence[5];
 	color tempColor;
 


### PR DESCRIPTION
New wording of 'a bundle of' causes macos curses target to crash on inventory open (it's strict about SIGABRTing when you overwrite the end of an array).